### PR TITLE
fix: correcting .desktop file so the applet shows in the cosmic settings menu

### DIFF
--- a/resources/app.desktop
+++ b/resources/app.desktop
@@ -9,3 +9,6 @@ StartupNotify=true
 Categories=COSMIC
 Keywords=COSMIC
 MimeType=
+NoDisplay=true
+X-CosmicApplet=true
+X-CosmicHoverPopup=Auto


### PR DESCRIPTION
The .desktop file was missing a few params that are necessary for an installed applet to show up in the applets menu in cosmic settings. 