### PR TITLE
fix: correct libcosmic features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ git = "https://github.com/pop-os/libcosmic.git"
 features = [
     # Applet support
     "applet",
+    "applet-token",
     # Accessibility support
     "a11y",
     # Uses cosmic-settings-daemon to watch for config file changes
@@ -40,8 +41,6 @@ features = [
     "winit",
     # Add Wayland support to winit
     "wayland",
-    # GPU-accelerated rendering
-    "wgpu",
 ]
 
 # Uncomment to test a locally-cloned libcosmic


### PR DESCRIPTION
Removed the wpgu libcosmic feature as this causes severe performance issues for the applet when running in the panel and it;s been confirmed that wgpu is not intended for applets.

Also added 'applet-token' libcosmic feature.